### PR TITLE
ENH: Add the remote as a parameter for indexing a given server

### DIFF
--- a/src/niquery/analysis/featuring.py
+++ b/src/niquery/analysis/featuring.py
@@ -35,8 +35,8 @@ from botocore import UNSIGNED  # type: ignore
 from botocore.config import Config  # type: ignore
 from tqdm import tqdm
 
-from niquery.data.remotes import OPENNEURO_BUCKET
-from niquery.utils.attributes import DATASETID, FULLPATH, VOLS
+from niquery.data.remotes import BUCKET, REMOTES
+from niquery.utils.attributes import DATASETID, FULLPATH, REMOTE, VOLS
 
 NBYTES = 512
 BYTE_RANGE = f"bytes=0-{NBYTES}"
@@ -44,8 +44,8 @@ BYTE_RANGE = f"bytes=0-{NBYTES}"
 s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
 
 
-def get_nii_timepoints_s3(filename: str) -> int:
-    """Compute the number of timepoints of the provided OpenNeuro NIfTI file.
+def get_nii_timepoints_s3(bucket: str, filename: str) -> int:
+    """Compute the number of timepoints of the provided NIfTI file.
 
     Computes the number of timepoints as the size along the last dimension from
     the header of the response bitstream without actually downloading the entire
@@ -53,6 +53,8 @@ def get_nii_timepoints_s3(filename: str) -> int:
 
     Parameters
     ----------
+    bucket : :obj:`str`
+        S3 bucket.
     filename : :obj:`str`
         NIfTI filename (e.g.
         'ds000149/sub-01/func/sub-01_task-picturemanualresponse_run-01_bold.nii.gz')
@@ -63,7 +65,7 @@ def get_nii_timepoints_s3(filename: str) -> int:
         Number of timepoints.
     """
 
-    response = s3.get_object(Bucket=OPENNEURO_BUCKET, Key=filename, Range=BYTE_RANGE)
+    response = s3.get_object(Bucket=bucket, Key=filename, Range=BYTE_RANGE)
     data = response["Body"].read()
 
     with gzip.GzipFile(fileobj=io.BytesIO(data), mode="rb") as img:
@@ -128,7 +130,9 @@ def extract_bold_features(bold_files: dict, max_workers: int = 8) -> tuple:
             for _, rec in df.iterrows():
                 futures[
                     executor.submit(
-                        get_nii_timepoints_s3, str(Path(dataset_id) / Path(rec[FULLPATH]))
+                        get_nii_timepoints_s3,
+                        REMOTES[rec[REMOTE]][BUCKET],
+                        str(Path(dataset_id) / Path(rec[FULLPATH])),
                     )
                 ] = (dataset_id, rec)
 
@@ -143,7 +147,9 @@ def extract_bold_features(bold_files: dict, max_workers: int = 8) -> tuple:
                 success_results[dataset_id].append(rec_vols)
             except Exception as e:
                 logging.warning(f"Failed to process {dataset_id}:{rec[FULLPATH]}: {e}")
-                failure_results.append({DATASETID: dataset_id, FULLPATH: rec[FULLPATH]})
+                failure_results.append(
+                    {REMOTE: rec[REMOTE], DATASETID: dataset_id, FULLPATH: rec[FULLPATH]}
+                )
 
     # Sort results before returning
     return {

--- a/src/niquery/analysis/filtering.py
+++ b/src/niquery/analysis/filtering.py
@@ -35,6 +35,7 @@ from niquery.utils.attributes import (
     FMRI_MODALITIES,
     HUMAN_SPECIES,
     MODALITIES,
+    REMOTE,
     SPECIES,
     VOLS,
 )
@@ -231,8 +232,10 @@ def filter_on_run_contribution(df: pd.DataFrame, contrib_thr: int, seed: int) ->
         .reset_index(drop=True)
     )
 
-    # Make datasetid column come first
-    return result[[DATASETID] + [c for c in result.columns if c != DATASETID]]
+    # Make the remote column come first, and the datasetid come second
+    return result[
+        [REMOTE, DATASETID] + [c for c in result.columns if c not in (REMOTE, DATASETID)]
+    ]
 
 
 def filter_runs(

--- a/src/niquery/data/fetching.py
+++ b/src/niquery/data/fetching.py
@@ -24,8 +24,8 @@
 from datalad.api import Dataset  # type: ignore[import-untyped]
 from datalad.support.exceptions import IncompleteResultsError  # type: ignore[import-untyped]
 
-from niquery.data.remotes import OPENNEURO_DS_TEMPLATE
-from niquery.utils.attributes import DATASETID, FULLPATH
+from niquery.data.remotes import DS_TEMPLATE, REMOTES
+from niquery.utils.attributes import DATASETID, FULLPATH, REMOTE
 
 
 def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
@@ -33,6 +33,7 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
 
     Downloads only the files listed in the provided DataFrame instance. The
     DataFrame is expected to contain at least the following columns:
+      - ``remote``: Remote server name (e.g., 'openneuro')
       - ``datasetid``: Dataset identifier (e.g., 'ds000231')
       - ``fullpath``: Path of the file within the dataset (e.g.
         'sub-01/func/sub-01_task-flavor_run-02_bold.nii.gz')
@@ -46,8 +47,8 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
     Parameters
     ----------
     df : :obj:`~pd.DataFrame`
-        Table containing at least 'datasetid', and 'fullpath' columns. Each row
-        corresponds to a file to be fetched.
+        Table containing at least 'remote', 'datasetid', and 'fullpath' columns.
+        Each row corresponds to a file to be fetched.
     out_dirname : :obj:`Path`
         Output directory where the datasets will be cloned and files stored.
     dataset_name : :obj:`str`
@@ -59,8 +60,8 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
         Dictionary of datasets and the filenames succeeded/failed for each.
     """
 
-    # Group by dataset_id, collect all file paths for each dataset
-    grouped = df.groupby(DATASETID)
+    # Group by remote, dataset_id; collect all file paths for each dataset
+    grouped = df.groupby([REMOTE, DATASETID])
 
     # Create new datalad dataset
     aggr_ds_path = out_dirname / dataset_name
@@ -74,9 +75,9 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
     success_results: dict[str, list[str]] = {}
     failure_results: dict[str, list[str]] = {}
 
-    # Loop over datasets
-    for dataset_id, file_list in grouped:
-        ds_url = OPENNEURO_DS_TEMPLATE.format(DATASET_ID=dataset_id)
+    # Loop over remote, dataset pairs
+    for (remote, dataset_id), file_list in grouped:
+        ds_url = REMOTES[remote][DS_TEMPLATE].format(DATASET_ID=dataset_id)
         ds_path = aggr_ds_path / str(dataset_id)
         if not ds_path.exists():
             ds = aggr_ds.clone(source=ds_url, path=str(ds_path))

--- a/src/niquery/data/remotes.py
+++ b/src/niquery/data/remotes.py
@@ -21,7 +21,16 @@
 #     https://www.nipreps.org/community/licensing/
 #
 
-# OpenNeuro
-OPENNEURO_BUCKET = "openneuro.org"
-OPENNEURO_GRAPHQL_URL = "https://openneuro.org/crn/graphql"
-OPENNEURO_DS_TEMPLATE = "https://github.com/OpenNeuroDatasets/{DATASET_ID}.git"
+BUCKET = "bucket"
+GRAPHQL_URL = "graphql_url"
+DS_TEMPLATE = "ds_template"
+
+OPENNEURO = "openneuro"
+
+REMOTES = {
+    OPENNEURO: {
+        BUCKET: "openneuro.org",
+        GRAPHQL_URL: "https://openneuro.org/crn/graphql",
+        DS_TEMPLATE: "https://github.com/OpenNeuroDatasets/{DATASET_ID}.git",
+    }
+}

--- a/src/niquery/utils/attributes.py
+++ b/src/niquery/utils/attributes.py
@@ -39,4 +39,5 @@ FMRI_MODALITIES = {"bold", "fmri", "mri"}
 DATASETID = "datasetid"
 FILENAME = "filename"
 FULLPATH = "fullpath"
+REMOTE = "remote"
 VOLS = "vols"

--- a/test/test_analysis_filtering.py
+++ b/test/test_analysis_filtering.py
@@ -34,7 +34,7 @@ from niquery.analysis.filtering import (
     identify_bold_files,
     identify_relevant_runs,
 )
-from niquery.utils.attributes import DATASETID, FILENAME, MODALITIES, SPECIES, VOLS
+from niquery.utils.attributes import DATASETID, FILENAME, MODALITIES, REMOTE, SPECIES, VOLS
 
 DSV_SEPARATOR = "\t"
 
@@ -124,10 +124,10 @@ def test_filter_on_timepoint_count():
 def test_filter_on_run_contribution_sampling_and_column_order():
     df = pd.DataFrame(
         [
-            {DATASETID: "ds1", VOLS: 100},
-            {DATASETID: "ds1", VOLS: 200},
-            {DATASETID: "ds1", VOLS: 300},
-            {DATASETID: "ds2", VOLS: 150},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 100},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 200},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 300},
+            {REMOTE: "myremote", DATASETID: "ds2", VOLS: 150},
         ]
     )
     out = filter_on_run_contribution(df, contrib_thr=2, seed=1234)
@@ -143,10 +143,10 @@ def test_filter_on_run_contribution_sampling_and_column_order():
 def test_filter_runs():
     df = pd.DataFrame(
         [
-            {DATASETID: "ds1", VOLS: 100},
-            {DATASETID: "ds1", VOLS: 200},
-            {DATASETID: "ds1", VOLS: 300},
-            {DATASETID: "ds2", VOLS: 150},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 100},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 200},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 300},
+            {REMOTE: "myremote", DATASETID: "ds2", VOLS: 150},
         ]
     )
     out = filter_runs(df, contrib_thr=2, min_timepoints=150, max_timepoints=300, seed=1234)
@@ -158,10 +158,10 @@ def test_filter_runs():
 def test_identify_relevant_runs():
     df = pd.DataFrame(
         [
-            {DATASETID: "ds1", VOLS: 100},
-            {DATASETID: "ds1", VOLS: 200},
-            {DATASETID: "ds1", VOLS: 300},
-            {DATASETID: "ds2", VOLS: 150},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 100},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 200},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 300},
+            {REMOTE: "myremote", DATASETID: "ds2", VOLS: 150},
         ]
     )
     out = identify_relevant_runs(

--- a/test/test_data_fetching.py
+++ b/test/test_data_fetching.py
@@ -27,8 +27,8 @@ import pandas as pd
 import pytest
 
 from niquery.data.fetching import fetch_datalad_remote_files
-from niquery.data.remotes import OPENNEURO_DS_TEMPLATE
-from niquery.utils.attributes import DATASETID, FULLPATH
+from niquery.data.remotes import DS_TEMPLATE, REMOTES
+from niquery.utils.attributes import DATASETID, FULLPATH, REMOTE
 
 
 @pytest.fixture
@@ -72,9 +72,10 @@ def mock_datalad(monkeypatch):
 
 def test_fetch_datalad_remote_files(tmp_path, mock_datalad):
     # Test that a new aggregate dataset is created
+    remote = "openneuro"
     df = pd.DataFrame(
         [
-            {DATASETID: "ds000001", FULLPATH: "sub-01/file1.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000001", FULLPATH: "sub-01/file1.nii.gz"},
         ]
     )
     out_dirname = tmp_path
@@ -90,7 +91,7 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad):
     # Test that subdatasets are cloned and saved
     df = pd.DataFrame(
         [
-            {DATASETID: "ds000002", FULLPATH: "sub-02/file2.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000002", FULLPATH: "sub-02/file2.nii.gz"},
         ]
     )
     out_dirname = tmp_path
@@ -102,7 +103,7 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad):
     fetch_datalad_remote_files(df, out_dirname, dataset_name)
 
     dataset_id = df.iloc[len(df) - 1][DATASETID]
-    ds_url = OPENNEURO_DS_TEMPLATE.format(DATASET_ID=dataset_id)
+    ds_url = REMOTES[remote][DS_TEMPLATE].format(DATASET_ID=dataset_id)
     ds_path = tmp_path / dataset_name / dataset_id
     assert any(
         source == ds_url and Path(path) == ds_path for source, path in mock_datalad.cloned_sources
@@ -112,8 +113,8 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad):
     # Test fetching files and success/failure reporting
     df = pd.DataFrame(
         [
-            {DATASETID: "ds000003", FULLPATH: "sub-03/success.nii.gz"},
-            {DATASETID: "ds000003", FULLPATH: "sub-03/failure_fail.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000003", FULLPATH: "sub-03/success.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000003", FULLPATH: "sub-03/failure_fail.nii.gz"},
         ]
     )
     out_dirname = tmp_path
@@ -129,7 +130,7 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad):
     # Test that an existing datalad dataset is not re-created
     df = pd.DataFrame(
         [
-            {DATASETID: "ds000004", FULLPATH: "sub-04/file.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000004", FULLPATH: "sub-04/file.nii.gz"},
         ]
     )
     out_dirname = tmp_path

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -51,7 +51,7 @@ def test_index_help():
     runner = CliRunner()
     result = runner.invoke(cli, [cmd_str, "--help"], prog_name=cli_name)
     assert result.exit_code == 0
-    assert result.output.startswith(f"Usage: {cli_name} {cmd_str} [OPTIONS] OUT_FILENAME")
+    assert result.output.startswith(f"Usage: {cli_name} {cmd_str} [OPTIONS] REMOTE OUT_FILENAME")
 
 
 def test_index_run(tmp_path):


### PR DESCRIPTION
Add the remote as a parameter for indexing a given server.

The remote is then stored along with the rest of the data so that the subsequent subcommands know what server they need to query. For now, we rely on the known OpenNeuro attributes.

Incidentally, fix a bug that made such that the cursors that did not contain any content were being counted as valid indexed datasets and and serialized to the output file containing the `None` string. Filter those cursors.