### PR TITLE
ENH: Add the remote as a parameter for indexing a given server

### DIFF
--- a/src/niquery/analysis/filtering.py
+++ b/src/niquery/analysis/filtering.py
@@ -35,6 +35,7 @@ from niquery.utils.attributes import (
     FMRI_MODALITIES,
     HUMAN_SPECIES,
     MODALITIES,
+    REMOTE,
     SPECIES,
     VOLS,
 )
@@ -231,8 +232,10 @@ def filter_on_run_contribution(df: pd.DataFrame, contrib_thr: int, seed: int) ->
         .reset_index(drop=True)
     )
 
-    # Make datasetid column come first
-    return result[[DATASETID] + [c for c in result.columns if c != DATASETID]]
+    # Make the remote column come first, and the datasetid come second
+    return result[
+        [REMOTE, DATASETID] + [c for c in result.columns if c not in (REMOTE, DATASETID)]
+    ]
 
 
 def filter_runs(

--- a/src/niquery/cli/run.py
+++ b/src/niquery/cli/run.py
@@ -84,15 +84,19 @@ def cli() -> None:
 
 
 @cli.command()
+@click.argument("remote", type=click.STRING)
 @click.argument("out_filename", type=click.Path(dir_okay=False, path_type=Path))
 @force_output
-def index(out_filename, force) -> None:
-    """Index existing dataset information from OpenNeuro.
+def index(remote, out_filename, force) -> None:  ## Stores tasks (specific to fMRI) (open issue)
+    """Index existing dataset information from a remote server.
 
-    The 'id', 'name', 'species', 'tag', 'dataset_doi', 'modalities', and 'tasks'
-    features of the available datasets are stored in the output file using a
-    delimiter-separated format.
+    The remote server needs to offer a GraphQL API.
 
+    The 'remote', 'id', 'name', 'species', 'tag', 'dataset_doi', 'modalities',
+    and 'tasks' features of the available datasets are stored in the output file
+    using a delimiter-separated format.
+
+    REMOTE       str    Remote server name
     OUT_FILENAME path   Output filename
     """
 
@@ -104,10 +108,12 @@ def index(out_filename, force) -> None:
         "Script called with arguments:\n" + "\n".join(f"  {k}: {v}" for k, v in locals().items())
     )
 
+    logging.info(f"Indexing {remote}...")
+
     start = time.time()
 
     # Precompute all cursors
-    cursors = get_cursors()
+    cursors = get_cursors(remote)
 
     # Fetch all pages in parallel
     edges = fetch_pages(cursors, max_workers=MAX_WORKERS)
@@ -130,14 +136,15 @@ def index(out_filename, force) -> None:
 @click.argument("out_dirname", type=click.Path(exists=True, file_okay=False, path_type=Path))
 @force_output
 def collect(in_filename, out_dirname, force) -> None:
-    """Collect human (f)MRI datasets' file information from OpenNeuro using IDs
-    read from the input file.
+    """Collect human (f)MRI datasets' file information from using the remotes
+    and IDs read from the input file.
 
     Only those datasets having 'human' in the species field are kept. Any
     dataset having one of {'bold', 'fmri', 'mri'} in the 'modality' field is
     considered an fMRI dataset. For each queried dataset, the list of files is
-    stored in a delimiter-separated file, along with the 'id', 'filename',
-    'size', 'directory', 'annexed', 'key', 'urls', and 'fullpath' features.
+    stored in a delimiter-separated file, along with the 'remote', 'id',
+    'filename', 'size', 'directory', 'annexed', 'key', 'urls', and 'fullpath'
+    features.
 
     IN_FILENAME path  Dataset list filename
 

--- a/src/niquery/data/fetching.py
+++ b/src/niquery/data/fetching.py
@@ -24,8 +24,8 @@
 from datalad.api import Dataset  # type: ignore[import-untyped]
 from datalad.support.exceptions import IncompleteResultsError  # type: ignore[import-untyped]
 
-from niquery.data.remotes import OPENNEURO_DS_TEMPLATE
-from niquery.utils.attributes import DATASETID, FULLPATH
+from niquery.data.remotes import DS_TEMPLATE, REMOTES
+from niquery.utils.attributes import DATASETID, FULLPATH, REMOTE
 from niquery.utils.decorators import require_datalad
 
 
@@ -36,6 +36,7 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
     Downloads only the files listed in the provided DataFrame instance. The
     DataFrame is expected to contain at least the following columns:
 
+      - ``remote``: Remote server name (e.g., 'openneuro')
       - ``datasetid``: Dataset identifier (e.g., 'ds000231')
       - ``fullpath``: Path of the file within the dataset (e.g.
         'sub-01/func/sub-01_task-flavor_run-02_bold.nii.gz')
@@ -49,8 +50,8 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
     Parameters
     ----------
     df : :obj:`~pd.DataFrame`
-        Table containing at least 'datasetid', and 'fullpath' columns. Each row
-        corresponds to a file to be fetched.
+        Table containing at least 'remote', 'datasetid', and 'fullpath' columns.
+        Each row corresponds to a file to be fetched.
     out_dirname : :obj:`Path`
         Output directory where the datasets will be cloned and files stored.
     dataset_name : :obj:`str`
@@ -62,8 +63,8 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
         Dictionary of datasets and the filenames succeeded/failed for each.
     """
 
-    # Group by dataset_id, collect all file paths for each dataset
-    grouped = df.groupby(DATASETID)
+    # Group by remote, dataset_id; collect all file paths for each dataset
+    grouped = df.groupby([REMOTE, DATASETID])
 
     # Create new datalad dataset
     aggr_ds_path = out_dirname / dataset_name
@@ -77,9 +78,9 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
     success_results: dict[str, list[str]] = {}
     failure_results: dict[str, list[str]] = {}
 
-    # Loop over datasets
-    for dataset_id, file_list in grouped:
-        ds_url = OPENNEURO_DS_TEMPLATE.format(DATASET_ID=dataset_id)
+    # Loop over remote, dataset pairs
+    for (remote, dataset_id), file_list in grouped:
+        ds_url = REMOTES[remote][DS_TEMPLATE].format(DATASET_ID=dataset_id)
         ds_path = aggr_ds_path / str(dataset_id)
         if not ds_path.exists():
             ds = aggr_ds.clone(source=ds_url, path=str(ds_path))

--- a/src/niquery/data/remotes.py
+++ b/src/niquery/data/remotes.py
@@ -21,7 +21,16 @@
 #     https://www.nipreps.org/community/licensing/
 #
 
-# OpenNeuro
-OPENNEURO_BUCKET = "openneuro.org"
-OPENNEURO_GRAPHQL_URL = "https://openneuro.org/crn/graphql"
-OPENNEURO_DS_TEMPLATE = "https://github.com/OpenNeuroDatasets/{DATASET_ID}.git"
+BUCKET = "bucket"
+GRAPHQL_URL = "graphql_url"
+DS_TEMPLATE = "ds_template"
+
+OPENNEURO = "openneuro"
+
+REMOTES = {
+    OPENNEURO: {
+        BUCKET: "openneuro.org",
+        GRAPHQL_URL: "https://openneuro.org/crn/graphql",
+        DS_TEMPLATE: "https://github.com/OpenNeuroDatasets/{DATASET_ID}.git",
+    }
+}

--- a/src/niquery/utils/attributes.py
+++ b/src/niquery/utils/attributes.py
@@ -39,4 +39,5 @@ FMRI_MODALITIES = {"bold", "fmri", "mri"}
 DATASETID = "datasetid"
 FILENAME = "filename"
 FULLPATH = "fullpath"
+REMOTE = "remote"
 VOLS = "vols"

--- a/test/test_analysis_featuring.py
+++ b/test/test_analysis_featuring.py
@@ -34,7 +34,7 @@ from niquery.analysis.featuring import (
     get_nii_timepoints_s3,
     get_nii_timepoints_url,
 )
-from niquery.utils.attributes import DATASETID, FULLPATH, VOLS
+from niquery.utils.attributes import DATASETID, FULLPATH, REMOTE, VOLS
 
 
 class DummyBody:
@@ -93,7 +93,7 @@ def test_get_nii_header_s3(monkeypatch):
     gz = gzip.compress(b"anybytes")
     monkeypatch.setattr("niquery.analysis.featuring.s3", DummyS3(gz))
     monkeypatch.setattr("niquery.analysis.featuring.nb.Nifti1Image", DummyNifti)
-    header = get_nii_header_s3("ds000001/path/file.nii.gz")
+    header = get_nii_header_s3("mybucket", "ds000001/path/file.nii.gz")
     assert isinstance(header, DummyNiftiHeader)
     assert header["dim"][4] == 123
 
@@ -124,7 +124,7 @@ def test_get_nii_timepoints_s3(monkeypatch):
     monkeypatch.setattr("niquery.analysis.featuring.s3", DummyS3(gz))
     monkeypatch.setattr("niquery.analysis.featuring.nb.Nifti1Image", DummyNifti)
 
-    n = get_nii_timepoints_s3("ds000001/path/file.nii.gz")
+    n = get_nii_timepoints_s3("mybucket", "ds000001/path/file.nii.gz")
     assert n == 123
 
 
@@ -149,15 +149,19 @@ def test_get_nii_timepoints_url(monkeypatch):
 
 def test_extract_bold_features(monkeypatch):
     # Prepare input dict: two datasets with small DataFrames
+    remote = "openneuro"
     df1 = pd.DataFrame(
-        [{FULLPATH: "sub-01/func/a_bold.nii.gz"}, {FULLPATH: "sub-01/func/b_bold.nii.gz"}]
+        [
+            {REMOTE: remote, FULLPATH: "sub-01/func/a_bold.nii.gz"},
+            {REMOTE: remote, FULLPATH: "sub-01/func/b_bold.nii.gz"},
+        ]
     )
-    df2 = pd.DataFrame([{FULLPATH: "sub-02/func/c_bold.nii.gz"}])
+    df2 = pd.DataFrame([{REMOTE: remote, FULLPATH: "sub-02/func/c_bold.nii.gz"}])
 
     datasets = {"ds1": df1, "ds2": df2}
 
-    def fake_get_nii_timepoints_s3(path_str):
-        # The implementation under test passes Path(dataset_id) / Path(df.iloc[0][FULLPATH])
+    def fake_get_nii_timepoints_s3(bucket, path_str):
+        # The implementation under test passes Path(dataset_id) / Path(rec[FULLPATH])
         # so we distinguish by dataset id in the path string.
         if "ds1" in path_str:
             return 50
@@ -178,4 +182,4 @@ def test_extract_bold_features(monkeypatch):
     assert success["ds2"] == []
 
     # Failures contain ds2's only record
-    assert failures == [{DATASETID: "ds2", FULLPATH: df2.iloc[0][FULLPATH]}]
+    assert failures == [{DATASETID: "ds2", FULLPATH: df2.iloc[0][FULLPATH], REMOTE: remote}]

--- a/test/test_analysis_filtering.py
+++ b/test/test_analysis_filtering.py
@@ -34,7 +34,7 @@ from niquery.analysis.filtering import (
     identify_bold_files,
     identify_relevant_runs,
 )
-from niquery.utils.attributes import DATASETID, FILENAME, MODALITIES, SPECIES, VOLS
+from niquery.utils.attributes import DATASETID, FILENAME, MODALITIES, REMOTE, SPECIES, VOLS
 
 DSV_SEPARATOR = "\t"
 
@@ -124,10 +124,10 @@ def test_filter_on_timepoint_count():
 def test_filter_on_run_contribution_sampling_and_column_order():
     df = pd.DataFrame(
         [
-            {DATASETID: "ds1", VOLS: 100},
-            {DATASETID: "ds1", VOLS: 200},
-            {DATASETID: "ds1", VOLS: 300},
-            {DATASETID: "ds2", VOLS: 150},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 100},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 200},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 300},
+            {REMOTE: "myremote", DATASETID: "ds2", VOLS: 150},
         ]
     )
     out = filter_on_run_contribution(df, contrib_thr=2, seed=1234)
@@ -143,10 +143,10 @@ def test_filter_on_run_contribution_sampling_and_column_order():
 def test_filter_runs():
     df = pd.DataFrame(
         [
-            {DATASETID: "ds1", VOLS: 100},
-            {DATASETID: "ds1", VOLS: 200},
-            {DATASETID: "ds1", VOLS: 300},
-            {DATASETID: "ds2", VOLS: 150},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 100},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 200},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 300},
+            {REMOTE: "myremote", DATASETID: "ds2", VOLS: 150},
         ]
     )
     out = filter_runs(df, contrib_thr=2, min_timepoints=150, max_timepoints=300, seed=1234)
@@ -158,10 +158,10 @@ def test_filter_runs():
 def test_identify_relevant_runs():
     df = pd.DataFrame(
         [
-            {DATASETID: "ds1", VOLS: 100},
-            {DATASETID: "ds1", VOLS: 200},
-            {DATASETID: "ds1", VOLS: 300},
-            {DATASETID: "ds2", VOLS: 150},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 100},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 200},
+            {REMOTE: "myremote", DATASETID: "ds1", VOLS: 300},
+            {REMOTE: "myremote", DATASETID: "ds2", VOLS: 150},
         ]
     )
     out = identify_relevant_runs(

--- a/test/test_data_fetching.py
+++ b/test/test_data_fetching.py
@@ -27,8 +27,8 @@ import pandas as pd
 import pytest
 
 from niquery.data.fetching import fetch_datalad_remote_files
-from niquery.data.remotes import OPENNEURO_DS_TEMPLATE
-from niquery.utils.attributes import DATASETID, FULLPATH
+from niquery.data.remotes import DS_TEMPLATE, REMOTES
+from niquery.utils.attributes import DATASETID, FULLPATH, REMOTE
 
 
 @pytest.fixture
@@ -75,9 +75,10 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad, monkeypatch):
     monkeypatch.setattr("niquery.utils.decorators.have_datalad", lambda: True)
 
     # Test that a new aggregate dataset is created
+    remote = "openneuro"
     df = pd.DataFrame(
         [
-            {DATASETID: "ds000001", FULLPATH: "sub-01/file1.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000001", FULLPATH: "sub-01/file1.nii.gz"},
         ]
     )
     out_dirname = tmp_path
@@ -93,7 +94,7 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad, monkeypatch):
     # Test that subdatasets are cloned and saved
     df = pd.DataFrame(
         [
-            {DATASETID: "ds000002", FULLPATH: "sub-02/file2.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000002", FULLPATH: "sub-02/file2.nii.gz"},
         ]
     )
     out_dirname = tmp_path
@@ -105,7 +106,7 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad, monkeypatch):
     fetch_datalad_remote_files(df, out_dirname, dataset_name)
 
     dataset_id = df.iloc[len(df) - 1][DATASETID]
-    ds_url = OPENNEURO_DS_TEMPLATE.format(DATASET_ID=dataset_id)
+    ds_url = REMOTES[remote][DS_TEMPLATE].format(DATASET_ID=dataset_id)
     ds_path = tmp_path / dataset_name / dataset_id
     assert any(
         source == ds_url and Path(path) == ds_path for source, path in mock_datalad.cloned_sources
@@ -115,8 +116,8 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad, monkeypatch):
     # Test fetching files and success/failure reporting
     df = pd.DataFrame(
         [
-            {DATASETID: "ds000003", FULLPATH: "sub-03/success.nii.gz"},
-            {DATASETID: "ds000003", FULLPATH: "sub-03/failure_fail.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000003", FULLPATH: "sub-03/success.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000003", FULLPATH: "sub-03/failure_fail.nii.gz"},
         ]
     )
     out_dirname = tmp_path
@@ -132,7 +133,7 @@ def test_fetch_datalad_remote_files(tmp_path, mock_datalad, monkeypatch):
     # Test that an existing datalad dataset is not re-created
     df = pd.DataFrame(
         [
-            {DATASETID: "ds000004", FULLPATH: "sub-04/file.nii.gz"},
+            {REMOTE: remote, DATASETID: "ds000004", FULLPATH: "sub-04/file.nii.gz"},
         ]
     )
     out_dirname = tmp_path

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -54,14 +54,15 @@ def test_index_help():
     runner = CliRunner()
     result = runner.invoke(cli, [cmd_str, "--help"], prog_name=cli_name)
     assert result.exit_code == 0
-    assert result.output.startswith(f"Usage: {cli_name} {cmd_str} [OPTIONS] OUT_FILENAME")
+    assert result.output.startswith(f"Usage: {cli_name} {cmd_str} [OPTIONS] REMOTE OUT_FILENAME")
 
 
 def test_index_run(tmp_path):
     cmd_str = "index"
     runner = CliRunner()
+    remote = "openneuro"
     out_fname = tmp_path / "openneuro_datasets.tsv"
-    result = runner.invoke(cli, [cmd_str, str(out_fname)], prog_name=cli_name)
+    result = runner.invoke(cli, [cmd_str, remote, str(out_fname)], prog_name=cli_name)
     assert result.exit_code == 0
     assert out_fname.is_file()
 


### PR DESCRIPTION
Add the remote as a parameter for indexing a given server.

The remote is then stored along with the rest of the data so that the subsequent subcommands know what server they need to query. For now, we rely on the known OpenNeuro attributes.

Incidentally, fix a bug that made such that the cursors that did not contain any content were being counted as valid indexed datasets and and serialized to the output file containing the `None` string. Filter those cursors.