### PR TITLE
DOC: Link further types to their documentation

### DIFF
--- a/src/niquery/analysis/filtering.py
+++ b/src/niquery/analysis/filtering.py
@@ -47,14 +47,14 @@ def filter_species_datasets(df: pd.DataFrame, species: str | list) -> pd.Series:
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         Dataset records.
     species : :obj:`str` or :obj:`list`
         Species to consider (case-insensitive).
 
     Returns
     -------
-    :obj:`~pd.Series`
+    :obj:`~pandas.Series`
         Mask of relevant datasets.
     """
 
@@ -72,14 +72,14 @@ def filter_modality_datasets(df: pd.DataFrame, modality: str | list) -> pd.Serie
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         Dataset records.
     modality : :obj:`str` or :obj:`list`
         Modalities to consider (case-insensitive).
 
     Returns
     -------
-    :obj:`~pd.Series`
+    :obj:`~pandas.Series`
         Mask of relevant datasets.
     """
 
@@ -102,7 +102,7 @@ def filter_nonrelevant_datasets(
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         Dataset records.
     species : :obj:`str` or :obj:`list`
         Species to consider (case-insensitive).
@@ -111,7 +111,7 @@ def filter_nonrelevant_datasets(
 
     Returns
     -------
-    :obj:`~pd.DataFrame`
+    :obj:`~pandas.DataFrame`
         Relevant dataset records.
 
     See Also
@@ -149,7 +149,7 @@ def filter_modality_records(fname: str, sep: str, suffix: str | list) -> pd.Data
 
     Returns
     -------
-    :obj:`~pd.DataFrame`
+    :obj:`~pandas.DataFrame`
         Modality file records.
     """
 
@@ -220,7 +220,7 @@ def filter_on_timepoint_count(
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         BOLD run information.
     min_timepoints : :obj:`int`
         Minimum number of time points.
@@ -229,7 +229,7 @@ def filter_on_timepoint_count(
 
     Returns
     -------
-    :obj:`~pd.DataFrame`
+    :obj:`~pandas.DataFrame`
         Filtered BOLD runs.
     """
 
@@ -247,7 +247,7 @@ def filter_on_run_contribution(df: pd.DataFrame, contrib_thr: int, seed: int) ->
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         BOLD run information.
     contrib_thr : :obj:`int`
         Contribution threshold in terms of number of runs.
@@ -256,7 +256,7 @@ def filter_on_run_contribution(df: pd.DataFrame, contrib_thr: int, seed: int) ->
 
     Returns
     -------
-    :obj:`~pd.DataFrame`
+    :obj:`~pandas.DataFrame`
         Filtered BOLD runs.
     """
 
@@ -295,7 +295,7 @@ def filter_runs(
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         BOLD run information.
     contrib_thr : :obj:`int`
         Contribution threshold in terms of number of runs.
@@ -308,7 +308,7 @@ def filter_runs(
 
     Returns
     -------
-    :obj:`~pd.DataFrame`
+    :obj:`~pandas.DataFrame`
         Filtered BOLD runs.
 
     See Also
@@ -346,7 +346,7 @@ def identify_relevant_runs(
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         BOLD run information.
     contrib_thr : :obj:`int`
         Contribution threshold in terms of the number of runs a dataset can
@@ -360,7 +360,7 @@ def identify_relevant_runs(
 
     Returns
     -------
-    :obj:`~pd.DataFrame`
+    :obj:`~pandas.DataFrame`
         Identified relevant BOLD runs.
 
     See Also

--- a/src/niquery/cli/utils.py
+++ b/src/niquery/cli/utils.py
@@ -21,8 +21,8 @@
 #     https://www.nipreps.org/community/licensing/
 #
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import click
 
@@ -37,12 +37,12 @@ def force_output(f: Callable) -> Callable:
 
     Parameters
     ----------
-    f : :obj:`Callable`
+    f : :obj:`~collections.abc.Callable`
         The function to be wrapped with the Click option.
 
     Returns
     -------
-    :obj:`Callable`
+    :obj:`~collections.abc.Callable`
         The decorated function with the ``--force / -f`` flag.
     """
 
@@ -60,14 +60,14 @@ def verify_output_path(path: Path, overwrite: bool = False):
 
     Verifies whether a path exists (if a file) or whether it is not empty
     (if a directory) it; raise an error if it exists/not empty and ``overwrite``
-    is ``False``.
+    is :obj:`False`.
 
     Parameters
     ----------
-    path : :obj:`Path`
+    path : :obj:`~pathlib.Path`
         Filename.
     overwrite : :obj:`bool`
-        ``True`` to allow overwriting the file/writing to a non-empty directory.
+        :obj:`True` to allow overwriting the file/writing to a non-empty directory.
     """
 
     if path.is_file() and not overwrite:

--- a/src/niquery/data/fetching.py
+++ b/src/niquery/data/fetching.py
@@ -49,10 +49,10 @@ def fetch_datalad_remote_files(df, out_dirname, dataset_name) -> tuple:
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         Table containing at least 'remote', 'datasetid', and 'fullpath' columns.
         Each row corresponds to a file to be fetched.
-    out_dirname : :obj:`Path`
+    out_dirname : :obj:`~pathlib.Path`
         Output directory where the datasets will be cloned and files stored.
     dataset_name : :obj:`str`
         Name of the dataset.

--- a/src/niquery/data/utils.py
+++ b/src/niquery/data/utils.py
@@ -23,7 +23,6 @@
 
 import re
 from pathlib import Path
-from typing import Pattern
 
 
 def filter_non_conforming_ds(dirname: Path) -> dict:
@@ -34,7 +33,7 @@ def filter_non_conforming_ds(dirname: Path) -> dict:
 
     Parameters
     ----------
-    dirname : :obj:`Path`
+    dirname : :obj:`~pathlib.Path`
         Directory where dataset files are located.
 
     Returns
@@ -52,7 +51,7 @@ def filter_non_conforming_ds(dirname: Path) -> dict:
     }
 
 
-def bids_dataset_name_pattern() -> Pattern[str]:
+def bids_dataset_name_pattern() -> re.Pattern[str]:
     r"""Return the compiled regex pattern to identify BIDS dataset filenames.
 
     Compiles a specific regex pattern designed to match filenames associated
@@ -63,7 +62,7 @@ def bids_dataset_name_pattern() -> Pattern[str]:
 
     Returns
     -------
-    :obj:`Pattern[str]`
+    :obj:`~re.Pattern[str]`
         A compiled regex pattern matching BIDS dataset filenames.
     """
 

--- a/src/niquery/io/utils.py
+++ b/src/niquery/io/utils.py
@@ -31,14 +31,14 @@ def append_label_to_filename(in_filename: Path, label: str) -> Path:
 
     Parameters
     ----------
-    in_filename : :obj:`Path`
+    in_filename : :obj:`~pathlib.Path`
         Filename.
     label : :obj:`str`
         Label tag.
 
-    Parameters
-    ----------
-    :obj:`Path`
+    Returns
+    -------
+    :obj:`~pathlib.Path`
         Composed filename.
     """
 
@@ -55,7 +55,7 @@ def write_dataset_file_lists(file_dict: dict, dirname: Path, sep: str) -> None:
     ----------
     file_dict: :obj:`dict`
         A mapping from dataset ID to a list of file metadata dicts.
-    dirname : :obj:`Path`
+    dirname : :obj:`~pathlib.Path`
         Directory where TSV files will be written.
     sep : :obj:`str`
         Separator.
@@ -78,7 +78,7 @@ def write_dataset_paths(dataset_paths: list, fname: Path, sep: str) -> None:
     ----------
     dataset_paths : :obj:`list`
         Dictionaries of dataset ID and fullpath.
-    fname : :obj:`Path`
+    fname : :obj:`~pathlib.Path`
         Filename.
     sep : :obj:`str`
         Separator.
@@ -95,7 +95,7 @@ def write_dataset_tags(dataset_tags: list, fname: Path, sep: str) -> None:
     ----------
     dataset_tags : :obj:`list`
         Dictionaries of dataset ID and snapshot tags.
-    fname : :obj:`Path`
+    fname : :obj:`~pathlib.Path`
         Filename.
     sep : :obj:`str`
         Separator.

--- a/src/niquery/query/querying.py
+++ b/src/niquery/query/querying.py
@@ -61,7 +61,7 @@ def fetch_page(gql_url: str, after_cursor: str | None = None) -> dict:
     gql_url : :obj:`str`
         GraphQL URL to fetch data from.
     after_cursor : :obj:`str`, optional
-        The pagination cursor indicating where to start. If ``None``, fetches
+        The pagination cursor indicating where to start. If :obj:`None`, fetches
         the first page.
 
     Returns
@@ -127,7 +127,7 @@ def get_cursors(remote: str) -> list:
     Returns
     -------
     cursors : :obj:`list`
-        List of remote and cursor tuples, where the first cursor is ``None``
+        List of remote and cursor tuples, where the first cursor is :obj:`None`
         (start of list), and the rest are page markers returned by GraphQL.
     """
 
@@ -200,7 +200,7 @@ def edges_to_dataframe(edges: list) -> pd.DataFrame:
 
     Returns
     -------
-    :obj:`~pd.DataFrame`
+    :obj:`~pandas.DataFrame`
         A DataFrame with the relevant dataset information, namely 'remote',
         'id', 'name', 'species', 'tag', 'dataset_doi', 'modalities', and
         'tasks'.
@@ -257,8 +257,8 @@ def post_with_retry(
 
     Returns
     -------
-    :obj:`requests.Response` or None
-        Request response. ``None`` if attempts failed.
+    :obj:`~requests.Response` or :obj:`None`
+        Request response. :obj:`None` if attempts failed.
     """
 
     for attempt in range(retries):
@@ -302,7 +302,7 @@ def query_snapshot_files(
     snapshot_tag : :obj:`str`
         The tag of the snapshot to query (e.g., '1.0.0').
     tree : :obj:`str`, optional
-        ID of a directory within the snapshot tree to query; use ``None`` to
+        ID of a directory within the snapshot tree to query; use :obj:`None` to
         start at the root.
 
     Returns
@@ -360,7 +360,7 @@ def query_snapshot_tree(
     snapshot_tag : :obj:`str`
         The tag of the snapshot to query (e.g., '1.0.0').
     tree : :obj:`str`, optional
-        ID of a directory within the snapshot tree to query; use ``None`` to
+        ID of a directory within the snapshot tree to query; use :obj:`None` to
         start at the root.
     parent_path : :obj:`str`, optional
         Relative path used to construct full file paths (used during recursion).
@@ -398,7 +398,7 @@ def query_dataset_files(gql_url: str, dataset_id: str, snapshot_tag: str) -> lis
     """Retrieve all files for a given dataset snapshot.
 
     This function takes a dataset metadata dictionary (typically a row from a
-    :obj:`~pd.DataFrame`), extracts the dataset ID and snapshot tag, and
+    :obj:`~pandas.DataFrame`), extracts the dataset ID and snapshot tag, and
     recursively queries all files in the snapshot. If the snapshot tag is
     missing or the request fails, an empty list is returned.
 
@@ -442,7 +442,7 @@ def query_datasets(df: pd.DataFrame, max_workers: int = 8) -> tuple:
 
     Parameters
     ----------
-    df : :obj:`~pd.DataFrame`
+    df : :obj:`~pandas.DataFrame`
         Dataset records.
     max_workers : :obj:`int`, optional
         Maximum number of parallel threads to use.

--- a/src/niquery/utils/decorators.py
+++ b/src/niquery/utils/decorators.py
@@ -22,7 +22,8 @@
 #
 
 import functools
-from typing import Any, Callable, TypeVar, cast
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
 
 import click
 
@@ -38,32 +39,34 @@ def require_datalad(func: F) -> F:
 
     Checks whether DataLad and its required dependencies are available in the
     environment: if DataLad or its required system dependencies are not
-    available, calling the decorated function will raise a :obj:`RuntimeError`
+    available, calling the decorated function will raise a :exc:`RuntimeError`
     with an informative message.
 
     Parameters
     ----------
-    func : :obj:`Callable`
+    func : :obj:`~collections.abc.Callable`
         The function to be decorated. This function should depend on DataLad
         being installed and the ``git`` and ``git-annex`` system tools being
         available.
 
     Returns
     -------
-    :obj:`Callable`
+    :obj:`~collections.abc.Callable`
         The wrapped function, which will only execute if DataLad is available.
 
     Raises
     ------
-    :obj:`RuntimeError`
+    :exc:`RuntimeError`
         If DataLad or its dependencies are not available when the decorated
         function is called.
 
-    Usage
-    -----
-    @require_datalad
-    def my_function(...):
-        ...
+    Examples
+    --------
+    .. code-block:: python
+
+        @require_datalad
+        def my_function(...):
+            ...
 
     See Also
     --------
@@ -80,34 +83,36 @@ def require_datalad(func: F) -> F:
 
 
 def require_datalad_click(func: F) -> F:
-    """Decorator for ``click``` command functions that require DataLad.
+    """Decorator for click command functions that require DataLad.
 
     If DataLad or its required system dependencies are not available, calling
-    the decorated function will raise a :obj:`RuntimeError` with an informative
+    the decorated function will raise a :exc:`RuntimeError` with an informative
     message.
 
     Checks whether DataLad and its required dependencies are available in the
     environment: if DataLad or its required system dependencies are not
-    available, it raises a :obj:`clickClickException` with a descriptive error
+    available, it raises a :exc:`~click.ClickException` with a descriptive error
     message.
 
     Returns
     -------
-    :obj:`Callable`
-        The wrapped ``click`` command function, which will only execute if
-        DataLad is available.
+    :obj:`~collections.abc.Callable`
+        The wrapped click command function, which will only execute if DataLad
+        is available.
 
     Raises
     ------
-    :obj:`clickClickException`
+    :exc:`~click.ClickException`
         If DataLad or its dependencies are not available.
 
-    Usage
-    -----
-    @click.command()
-    @require_datalad_click
-    def my_command():
-        ...
+    Examples
+    --------
+    .. code-block:: python
+
+        @click.command()
+        @require_datalad_click
+        def my_command():
+            ...
 
     See Also
     --------

--- a/src/niquery/utils/logging.py
+++ b/src/niquery/utils/logging.py
@@ -54,9 +54,9 @@ def configure_logging(dirname: Path, filename: str) -> None:
 
     Parameters
     ----------
-    dirname : :obj:`Path`
+    dirname : :obj:`~pathlib.Path`
         Directory where to save the logfile.
-    filename : :obj:`Path`
+    filename : :obj:`~pathlib.Path`
         Filename. Will be appended to the package name to create the log
         filename.
     """

--- a/src/niquery/utils/optpckg.py
+++ b/src/niquery/utils/optpckg.py
@@ -32,8 +32,8 @@ def have_datalad() -> bool:
     Returns
     -------
     :obj:`bool`
-        True if DataLad and its required system dependencies are available,
-        False otherwise.
+        :obj:`True` if DataLad and its required system dependencies are
+        available, :obj:`False` otherwise.
     """
 
     try:


### PR DESCRIPTION
Link further types to their documentation:
- Use the fully qualified name to link pandas objects: e.g. use :obj:`pandas.DataFrame` instead of :obj:`pd.DataFrame`. The aliases are not listed in the pandas inventory file of pandas and thus, do not get resolved.
- Use the fully qualified name to document `pathlib.Path` types.
- Add the missing dot for the qualified names for the `click` exceptions in the `utils.decorators` module.
- Import `Callable` from `collections.abc`: the `typing.Callable` is a deprecated alias to it: https://docs.python.org/3/library/typing.html#typing.Callable
- Use :obj:`None`, :obj:`True`, and obj:`None` to link their appearances to the corresponding Python constants.

Take advantage of the commit to:
- Fix the return docstring section header in a function of the `io.utils` module.
- Use `Examples` as the docstring section header for the usage across `utils.decorators` functions as `Usage` is not standard in NumPy-style documentation. Also, make the code be highlighted properly using the `.. code-block:: python` directive.
- Add the tilde to other types to shorten the displayed link to the last component. Increases consistency across the documentation.
- Prefer using `re.Pattern` instead of `typing.Pattern`, which is deprecated: https://docs.python.org/3/library/typing.html#typing.Pattern
- Prefer using the `exc` role for exceptions and errors.
- Remove the double backticks when mentioning `click` in the `utils.decorators` module for the sake of consistency with mentions to other packages (e.g. `DataLad`). Avoids an error due to mismatched backticks (two opening; three closing).