### PR TITLE
FIX: Use the GraphQL `key` field to query directories

### DIFF
--- a/src/niquery/query/querying.py
+++ b/src/niquery/query/querying.py
@@ -37,6 +37,7 @@ from niquery.utils.attributes import (
     FILENAME,
     FULLPATH,
     ID,
+    KEY,
     MODALITIES,
     NAME,
     REMOTE,
@@ -384,7 +385,7 @@ def query_snapshot_tree(
         current_path = f"{parent_path}/{f[FILENAME]}".lstrip("/")
         if f[DIRECTORY]:
             sub_files = query_snapshot_tree(
-                gql_url, dataset_id, snapshot_tag, f[ID], parent_path=current_path
+                gql_url, dataset_id, snapshot_tag, f[KEY], parent_path=current_path
             )
             all_files.extend(sub_files)
         else:

--- a/src/niquery/utils/attributes.py
+++ b/src/niquery/utils/attributes.py
@@ -24,6 +24,7 @@
 # Attributes returned by GraphQL when querying OpenNeuro
 DATASET_DOI = "DatasetDOI"
 ID = "id"
+KEY = "key"
 MODALITIES = "modalities"
 NAME = "name"
 SPECIES = "species"

--- a/test/test_query_querying.py
+++ b/test/test_query_querying.py
@@ -47,6 +47,7 @@ from niquery.utils.attributes import (
     FILENAME,
     FULLPATH,
     ID,
+    KEY,
     MODALITIES,
     NAME,
     REMOTE,
@@ -290,12 +291,12 @@ def test_query_snapshot_files_ok(monkeypatch):
 def test_query_snapshot_tree_recurses(monkeypatch):
     # First call returns a directory and a file
     root_files = [
-        {ID: "dir1", FILENAME: "sub", DIRECTORY: True},
-        {ID: "f1", FILENAME: "rootfile.txt", DIRECTORY: False},
+        {KEY: "dir1", FILENAME: "sub", DIRECTORY: True},
+        {KEY: "f1", FILENAME: "rootfile.txt", DIRECTORY: False},
     ]
     # Second call returns a file within the directory
     sub_files = [
-        {ID: "f2", FILENAME: "subfile.txt", DIRECTORY: False},
+        {KEY: "f2", FILENAME: "subfile.txt", DIRECTORY: False},
     ]
     calls = []
 


### PR DESCRIPTION
Use the GraphQL `key` field to query directories: the contents of the directories were no longer being listed when collecting (`niquery collect`) the dataset information, and only the files at the root of the datasets (e.g. `CHANGES`, `dataset_description.json`, etc.) were being listed. This made such that the no NIfTI files were being listed for subset selection purposes.

This patch set employs the `key` field of the returned GraphQL response to recursively query the directories. This allows them to be effectively traversed, and the NIfTI files to be listed and written in the dataset content TSV files.