### PR TITLE
MNT: Prepend `src` for the coverage path

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands_pre =
   uv pip install datalad
   uv tool install --with-executables-from=datalad-osf,datalad-next datalad
 commands =
-  pytest -sv --doctest-modules --cov niquery --cov-report xml \
+  pytest -sv --doctest-modules --cov src/niquery --cov-report xml \
   --junitxml=test-results.xml -v src test {posargs:-n auto}
 
 [testenv:docs]


### PR DESCRIPTION
Prepend `src` for the coverage path; otherwise, the coverage of the modules `analysis.featuring.py`, `analysis.filtering.py`, and `cli.run.py` are reported to be 0%, even if there they are covered extensively by existing tests.