### PR TITLE
DOC: Make `autodoc` signature formatting robust for `typing.TypeVar`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -246,6 +246,27 @@ import inspect
 def autodoc_process_signature(app, what, name, obj, options, signature, return_annotation):
     """Replace the class signature by the signature from cls.__init__"""
 
+    # Make TypeVar rendering robust (and keep it documented)
+    # Sphinx autodoc may try to "format signature" for TypeVar and crash.
+    # If obj is a TypeVar instance, provide a simple, stable signature.
+    try:
+        if type(obj) is typing.TypeVar:
+            # Example: "F" or "_F"
+            tv_name = getattr(obj, "__name__", name.rsplit(".", 1)[-1])
+            # Best-effort to show bounds/constraints without triggering internal errors
+            bound = getattr(obj, "__bound__", None)
+            constraints = getattr(obj, "__constraints__", ())
+            if constraints:
+                rhs = " | ".join(getattr(c, "__name__", repr(c)) for c in constraints)
+            elif bound is not None:
+                rhs = getattr(bound, "__name__", repr(bound))
+            else:
+                rhs = "Any"
+            return f" = TypeVar({tv_name!r}, bound={rhs})", return_annotation
+    except Exception:
+        # If anything goes wrong, fall back to Sphinx defaults
+        return signature, return_annotation
+
     if what == "class" and hasattr(obj, "__init__"):
         try:
             init_signature = inspect.signature(obj.__init__)


### PR DESCRIPTION
Make autodoc signature formatting robust for `typing.TypeVar`.

Sphinx autodoc was emitting a warning when it tried to format the signature for a `TypeVar` exposed in the API docs.

Add a small `autodoc-process-signature` guard in `docs/conf.py` that detects `typing.TypeVar` instances and returns a stable, safe signature representation, preventing the warning while keeping the `TypeVar` documented in the apidoc-generated pages.

Fixes:
```
WARNING: error while formatting signature for
niquery.utils.decorators.TypeVar: list assignment index out of range
[autodoc]
```

raised for example at:
https://github.com/nipreps/niquery/actions/runs/24147153907/job/70463995648?pr=33#step:6:82