### PR TITLE
MNT: Comment cron event in GHA test workflow file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ on:
       - maint/*
   # Allow job to be triggered manually from GitHub interface
   workflow_dispatch:
-  schedule:
-    - cron: '0 22 * * 0' # At 22:00 UTC every Sunday
+  # schedule:
+  #   - cron: '0 22 * * 0' # At 22:00 UTC every Sunday
 
 defaults:
   run:


### PR DESCRIPTION
Comment cron event in GHA test workflow file: the job fails frequently due to server-side issues (e.g. 503 errors), and they need to be re-triggred manually until tests pass.

So, prioritize maintainers' time by commenting the event.