### PR TITLE
FIX: Use GraphQL ID for the snapshot files tree argument

### DIFF
--- a/src/niquery/query/querying.py
+++ b/src/niquery/query/querying.py
@@ -314,7 +314,7 @@ def query_snapshot_files(
     """
 
     query = """
-    query getSnapshotFiles($datasetId: ID!, $tag: String!, $tree: String) {
+    query getSnapshotFiles($datasetId: ID!, $tag: String!, $tree: ID) {
       snapshot(datasetId: $datasetId, tag: $tag) {
         files(tree: $tree) {
           id


### PR DESCRIPTION
OpenNeuro v5.0.0 introduced breaking GraphQL changes to file tree traversal, including using dataset file id values for loading child trees. Update the snapshot files query to declare tree as ID instead of String so the request matches the current GraphQL contract.

OpenNeuro v5.0.0 release notes, published 2026-04-16: https://github.com/OpenNeuroOrg/openneuro/releases/tag/v5.0.0