### PR TITLE
FIX: Use DatasetFile ids for snapshot tree traversal

### DIFF
--- a/src/niquery/analysis/filtering.py
+++ b/src/niquery/analysis/filtering.py
@@ -36,7 +36,6 @@ from niquery.utils.attributes import (
     FILENAME,
     FULLPATH,
     ID,
-    KEY,
     MODALITIES,
     REMOTE,
     SIZE,
@@ -176,7 +175,6 @@ def filter_modality_records(fname: str, sep: str, suffix: str | list) -> pd.Data
         SIZE: int,
         DIRECTORY: bool,
         ANNEXED: bool,
-        KEY: str,
         URLS: str,
         FULLPATH: str,
     }

--- a/src/niquery/query/querying.py
+++ b/src/niquery/query/querying.py
@@ -37,7 +37,6 @@ from niquery.utils.attributes import (
     FILENAME,
     FULLPATH,
     ID,
-    KEY,
     MODALITIES,
     NAME,
     REMOTE,
@@ -322,7 +321,6 @@ def query_snapshot_files(
           size
           directory
           annexed
-          key
           urls
         }
       }
@@ -385,7 +383,7 @@ def query_snapshot_tree(
         current_path = f"{parent_path}/{f[FILENAME]}".lstrip("/")
         if f[DIRECTORY]:
             sub_files = query_snapshot_tree(
-                gql_url, dataset_id, snapshot_tag, f[KEY], parent_path=current_path
+                gql_url, dataset_id, snapshot_tag, f[ID], parent_path=current_path
             )
             all_files.extend(sub_files)
         else:

--- a/src/niquery/utils/attributes.py
+++ b/src/niquery/utils/attributes.py
@@ -24,7 +24,6 @@
 # Attributes returned by GraphQL when querying OpenNeuro
 DATASET_DOI = "DatasetDOI"
 ID = "id"
-KEY = "key"
 MODALITIES = "modalities"
 NAME = "name"
 SPECIES = "species"

--- a/test/test_query_querying.py
+++ b/test/test_query_querying.py
@@ -47,7 +47,6 @@ from niquery.utils.attributes import (
     FILENAME,
     FULLPATH,
     ID,
-    KEY,
     MODALITIES,
     NAME,
     REMOTE,
@@ -291,12 +290,12 @@ def test_query_snapshot_files_ok(monkeypatch):
 def test_query_snapshot_tree_recurses(monkeypatch):
     # First call returns a directory and a file
     root_files = [
-        {KEY: "dir1", FILENAME: "sub", DIRECTORY: True},
-        {KEY: "f1", FILENAME: "rootfile.txt", DIRECTORY: False},
+        {ID: "dir1", FILENAME: "sub", DIRECTORY: True},
+        {ID: "f1", FILENAME: "rootfile.txt", DIRECTORY: False},
     ]
     # Second call returns a file within the directory
     sub_files = [
-        {KEY: "f2", FILENAME: "subfile.txt", DIRECTORY: False},
+        {ID: "f2", FILENAME: "subfile.txt", DIRECTORY: False},
     ]
     calls = []
 
@@ -314,6 +313,10 @@ def test_query_snapshot_tree_recurses(monkeypatch):
     fullpaths = sorted(f[FULLPATH] for f in out)
     assert fullpaths == ["rootfile.txt", "sub/subfile.txt"]
     assert calls == ["root", "dir1"]
+    assert out == [
+        {ID: "f2", FILENAME: "subfile.txt", DIRECTORY: False, FULLPATH: "sub/subfile.txt"},
+        {ID: "f1", FILENAME: "rootfile.txt", DIRECTORY: False, FULLPATH: "rootfile.txt"},
+    ]
 
 
 def test_query_snapshot_tree_handles_exception(monkeypatch, caplog):


### PR DESCRIPTION
Use DatasetFile ids for snapshot tree traversal and stop querying removed key field.

OpenNeuro v5.0.0 introduced breaking GraphQL changes to file tree traversal, including using dataset file id values for loading child trees. Update the snapshot files query to declare tree as ID instead of String so the request matches the current GraphQL contract.

OpenNeuro v5.0.0 release notes, published 2026-04-16:
https://github.com/OpenNeuroOrg/openneuro/releases/tag/v5.0.0

Remove the `KEY` attribute instances as its value is no longer used/relevant.