### PR TITLE
MNT: Make doc update workflow robust to first-time release-series

### DIFF
--- a/.github/workflows/docs-build-update.yml
+++ b/.github/workflows/docs-build-update.yml
@@ -65,7 +65,7 @@ jobs:
         rm -rf ${MAJOR_MINOR}
         cp -r $HOME/docs/$CURBRANCH $PWD/${MAJOR_MINOR}
         git add ${MAJOR_MINOR}
-        python -c "from pathlib import Path; import json; f=Path('versions.json'); d=json.loads(f.read_text()); d['tags'].append(\"${MAJOR_MINOR}\"); d['tags'] = list(sorted(set(d['tags']))); f.write_text(json.dumps(d, indent=4)); print('Updated versions.json')"
+        python -c "from pathlib import Path; import json; f=Path('versions.json'); d=json.loads(f.read_text()) if f.exists() else {'tags': []}; d['tags'].append(\"${MAJOR_MINOR}\"); d['tags'] = list(sorted(set(d['tags']))); f.write_text(json.dumps(d, indent=4)); print('Updated versions.json')"
         git add versions.json
         git commit -m "rel(${CURBRANCH}): Update docs of ${MAJOR_MINOR} series" || true
         git push


### PR DESCRIPTION
Make the documentation update workflow robust to first-time release-series publication: make the workflow create `versions.json` when it is missing before reading/updating it.

Fixes:
```
fatal: pathspec '26.0/' did not match any files
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.12/pathlib.py", line 1029, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/pathlib.py", line 1015, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  FileNotFoundError: [Errno 2] No such file or directory: 'versions.json'
```

raised for example in:
https://github.com/nipreps/niquery/actions/runs/26872833892/job/79254360667#step:7:34